### PR TITLE
fixed external link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 This repository contains the practical notebooks for the Deep Learning Indaba
 2019, held in Kenyatta University, Kenya.
 
-See [www.deeplearningindaba.com](www.deeplearningindaba.com) for more details.
+See [www.deeplearningindaba.com](http://www.deeplearningindaba.com) for more details.
 
 This is not an official Google product.


### PR DESCRIPTION
Hello! 

The link to deeplearningindaba.com seems broken in the README file, as it tries to load https://github.com/deep-learning-indaba/indaba-pracs-2019/blob/master/www.deeplearningindaba.com. This change made it work for me. 